### PR TITLE
Added enable/disable option and relevant script edits

### DIFF
--- a/addons/XIM_Core/config.cpp
+++ b/addons/XIM_Core/config.cpp
@@ -27,21 +27,21 @@ class CfgVehicles
             class skipSong
             {
                 displayName = "Skip song";
-                condition = "((leader (group _player) == _player) or !isMultiplayer) and (!(group _player getVariable ['XIM_bMusicStopped', false]))";
+                condition = "((leader (group _player) == _player) or !isMultiplayer) and (!(group _player getVariable ['XIM_bMusicStopped', false])) and XIM_systemEnabled";
                 exceptions[] = {};
                 statement = "[_player,false] call XIM_fncPlayNext"; //DON'T USE TIMEOUT
             };
             class stopMusic
             {
                 displayName = "Stop music";
-                condition = "((leader (group _player) == _player) or !isMultiplayer) and (!(group _player getVariable ['XIM_bMusicStopped', false]))";
+                condition = "((leader (group _player) == _player) or !isMultiplayer) and (!(group _player getVariable ['XIM_bMusicStopped', false])) and XIM_systemEnabled";
                 exceptions[] = {};
                 statement = "[] call XIM_fncStopMusic";
             };
             class startMusic
             {
                 displayName = "Start music";
-                condition = "((leader (group _player) == _player) or !isMultiplayer) and (group _player getVariable ['XIM_bMusicStopped', false])";
+                condition = "((leader (group _player) == _player) or !isMultiplayer) and (group _player getVariable ['XIM_bMusicStopped', false]) and XIM_systemEnabled";
                 exceptions[] = {};
                 statement = "[] call XIM_fncStartMusic";
             };

--- a/addons/XIM_Core/config.cpp
+++ b/addons/XIM_Core/config.cpp
@@ -27,21 +27,21 @@ class CfgVehicles
             class skipSong
             {
                 displayName = "Skip song";
-                condition = "((leader (group _player) == _player) or !isMultiplayer) and (!(group _player getVariable ['XIM_bMusicStopped', false])) and XIM_systemEnabled";
+                condition = "((leader (group _player) == _player) or !isMultiplayer) and (!(group _player getVariable ['XIM_bMusicStopped', false])) and XIM_bSystemEnabled";
                 exceptions[] = {};
                 statement = "[_player,false] call XIM_fncPlayNext"; //DON'T USE TIMEOUT
             };
             class stopMusic
             {
                 displayName = "Stop music";
-                condition = "((leader (group _player) == _player) or !isMultiplayer) and (!(group _player getVariable ['XIM_bMusicStopped', false])) and XIM_systemEnabled";
+                condition = "((leader (group _player) == _player) or !isMultiplayer) and (!(group _player getVariable ['XIM_bMusicStopped', false])) and XIM_bSystemEnabled";
                 exceptions[] = {};
                 statement = "[] call XIM_fncStopMusic";
             };
             class startMusic
             {
                 displayName = "Start music";
-                condition = "((leader (group _player) == _player) or !isMultiplayer) and (group _player getVariable ['XIM_bMusicStopped', false]) and XIM_systemEnabled";
+                condition = "((leader (group _player) == _player) or !isMultiplayer) and (group _player getVariable ['XIM_bMusicStopped', false]) and XIM_bSystemEnabled";
                 exceptions[] = {};
                 statement = "[] call XIM_fncStartMusic";
             };

--- a/addons/XIM_Core/scripts/autostart/XEH_PreInit.sqf
+++ b/addons/XIM_Core/scripts/autostart/XEH_PreInit.sqf
@@ -5,6 +5,16 @@ if (isMultiplayer) then // if client is in multiplayer
 	if (isServer) then // runs on the dedicated server, or player host, either way it runs on machine id 2
 	{
 		[
+            "XIM_systemEnabled", // the name of the variable which the output from the slider is assigned to
+            "CHECKBOX", // interactive slider setting type
+            ["Enable the entire system", "Untick this box to disable music playing for missions where a Zeus/other script handles music."], // name and tooltip for the setting
+            ["XIM - X's Immersive Music", "Core"], // category the setting is in
+            [true], // default value of true
+            1, // enables synchronising the variable across clients. It is better to keep this synchronized as this is a major setting even though some players might not want to use it — they can simply set their music volume to 0.
+            {} // executes nothing when the setting is changed, as it is not necessary
+        ] call cba_settings_fnc_init;
+        
+        [
             "XIM_bNowPlayingEnabled", // the name of the variable which the output from the slider is assigned to
             "CHECKBOX", // interactive slider setting type
             ["Enable 'Now Playing' UI", "Enable or disable the UI which displays the song currently playing when it starts."], // name and tooltip for the setting
@@ -99,6 +109,16 @@ if (isMultiplayer) then // if client is in multiplayer
 
     if (hasInterface) then // if the system has a "real player", false for dedicated and headless clients
 	{
+        [
+            "XIM_systemEnabled", // the name of the variable which the output from the slider is assigned to
+            "CHECKBOX", // interactive slider setting type
+            ["Enable the entire system", "Untick this box to disable music playing for missions where a Zeus/other script handles music."], // name and tooltip for the setting
+            ["XIM - X's Immersive Music", "Core"], // category the setting is in
+            [true], // default value of true
+            1, // enables synchronising the variable across clients. It is better to keep this synchronized as this is a major setting even though some players might not want to use it — they can simply set their music volume to 0.
+            {} // executes nothing when the setting is changed, as it is not necessary
+        ] call cba_settings_fnc_init;
+        
         [
             "XIM_bNowPlayingEnabled", // the name of the variable which the output from the slider is assigned to
             "CHECKBOX", // interactive slider setting type
@@ -195,6 +215,16 @@ if (isMultiplayer) then // if client is in multiplayer
 } 
 else // if client is in singleplayer
 {
+    [
+        "XIM_systemEnabled", // the name of the variable which the output from the slider is assigned to
+        "CHECKBOX", // interactive slider setting type
+        ["Enable the entire system", "Untick this box to disable music playing for missions where a Zeus or another script handles music."], // name and tooltip for the setting
+        ["XIM - X's Immersive Music", "Core"], // category the setting is in
+        [true], // default value of true
+        1, // enables synchronising the variable across clients. It is better to keep this synchronized as this is a major setting even though some players might not want to use it — they can simply set their music volume to 0.
+        {} // executes nothing when the setting is changed, as it is not necessary
+    ] call cba_settings_fnc_init;
+        
     [
         "XIM_iCombatRange", // the name of the variable which the output from the slider is assigned to
         "SLIDER", // interactive slider setting type

--- a/addons/XIM_Core/scripts/autostart/XEH_PreInit.sqf
+++ b/addons/XIM_Core/scripts/autostart/XEH_PreInit.sqf
@@ -5,7 +5,7 @@ if (isMultiplayer) then // if client is in multiplayer
 	if (isServer) then // runs on the dedicated server, or player host, either way it runs on machine id 2
 	{
 		[
-            "XIM_systemEnabled", // the name of the variable which the output from the slider is assigned to
+            "XIM_bSystemEnabled", // the name of the variable which the output from the slider is assigned to
             "CHECKBOX", // interactive slider setting type
             ["Enable the entire system", "Untick this box to disable music playing for missions where a Zeus/other script handles music."], // name and tooltip for the setting
             ["XIM - X's Immersive Music", "Core"], // category the setting is in
@@ -110,7 +110,7 @@ if (isMultiplayer) then // if client is in multiplayer
     if (hasInterface) then // if the system has a "real player", false for dedicated and headless clients
 	{
         [
-            "XIM_systemEnabled", // the name of the variable which the output from the slider is assigned to
+            "XIM_bSystemEnabled", // the name of the variable which the output from the slider is assigned to
             "CHECKBOX", // interactive slider setting type
             ["Enable the entire system", "Untick this box to disable music playing for missions where a Zeus/other script handles music."], // name and tooltip for the setting
             ["XIM - X's Immersive Music", "Core"], // category the setting is in
@@ -216,7 +216,7 @@ if (isMultiplayer) then // if client is in multiplayer
 else // if client is in singleplayer
 {
     [
-        "XIM_systemEnabled", // the name of the variable which the output from the slider is assigned to
+        "XIM_bSystemEnabled", // the name of the variable which the output from the slider is assigned to
         "CHECKBOX", // interactive slider setting type
         ["Enable the entire system", "Untick this box to disable music playing for missions where a Zeus or another script handles music."], // name and tooltip for the setting
         ["XIM - X's Immersive Music", "Core"], // category the setting is in

--- a/addons/XIM_Core/scripts/multiplayer/client.sqf
+++ b/addons/XIM_Core/scripts/multiplayer/client.sqf
@@ -27,9 +27,9 @@ XIM_fncStartMusic = // starts playing music for all clients in the group
 
 addMusicEventHandler ["MusicStart", {
 	
-	if !(XIM_systemEnabled) exitWith {}; 	//if mission has disabled XIM, they probably don't want the 'Now Playing' UI to pop up when Zeus/other script starts a song 
+	if !(XIM_bSystemEnabled) exitWith {}; 	//if mission has disabled XIM, they probably don't want the 'Now Playing' UI to pop up when Zeus/other script starts a song 
 											//then again, the 'Now Playing' UI is kinda cool and Zeus/other might want it on. Consider removing this line and just adding a disclaimer to
-											//'XIM_systemEnabled' in the CBA options that they also need to disable XIM_bNowPlayingEnabled if they want to hide the 'Now Playing' UI too.
+											//'XIM_bSystemEnabled' in the CBA options that they also need to disable XIM_bNowPlayingEnabled if they want to hide the 'Now Playing' UI too.
 	
 	if (XIM_bNowPlayingEnabled) then
 	{

--- a/addons/XIM_Core/scripts/multiplayer/client.sqf
+++ b/addons/XIM_Core/scripts/multiplayer/client.sqf
@@ -26,6 +26,11 @@ XIM_fncStartMusic = // starts playing music for all clients in the group
 // ======================================== EVENT HANDLERS ========================================
 
 addMusicEventHandler ["MusicStart", {
+	
+	if !(XIM_systemEnabled) exitWith {}; 	//if mission has disabled XIM, they probably don't want the 'Now Playing' UI to pop up when Zeus/other script starts a song 
+											//then again, the 'Now Playing' UI is kinda cool and Zeus/other might want it on. Consider removing this line and just adding a disclaimer to
+											//'XIM_systemEnabled' in the CBA options that they also need to disable XIM_bNowPlayingEnabled if they want to hide the 'Now Playing' UI too.
+	
 	if (XIM_bNowPlayingEnabled) then
 	{
 		private _trackname = getText (configFile >> "CfgMusic" >> _this select 0 >> "name");

--- a/addons/XIM_Core/scripts/multiplayer/server.sqf
+++ b/addons/XIM_Core/scripts/multiplayer/server.sqf
@@ -144,6 +144,11 @@ fncXIM_MusicRemote = {
 	params ["_gXIMGroup", "_bXIMCombatState","_XIMMusicRemoteFunction"]; //Defining params
 	private _groupOwnerIDs = []; // declare the empty array _groupOwnerIDs
 
+	if !(XIM_systemEnabled) exitWith {}; 	//don't tell clients to play music if entire system is stopped. Only this function has this for maximum 
+											//compatibility (i.e. able to start and stop system without restarting the mission), but consider doing this in all the functions for 
+											//performance gains (so XIM scripts are barely running so resources aren't wasted on calculating what music to play even if that music
+											//will never actually get played thanks to this line in fncXIM_MusicRemote)?
+
 	if (!(_gXIMGroup getVariable ["XIM_bMusicStopped", false])) then // if XIM_bMusicStopped is false
 	{
 		(units _gXIMGroup) apply {_groupOwnerIDs pushBackUnique (owner _x)}; //Retrieving ID's for players in group

--- a/addons/XIM_Core/scripts/multiplayer/server.sqf
+++ b/addons/XIM_Core/scripts/multiplayer/server.sqf
@@ -144,7 +144,7 @@ fncXIM_MusicRemote = {
 	params ["_gXIMGroup", "_bXIMCombatState","_XIMMusicRemoteFunction"]; //Defining params
 	private _groupOwnerIDs = []; // declare the empty array _groupOwnerIDs
 
-	if !(XIM_systemEnabled) exitWith {}; 	//don't tell clients to play music if entire system is stopped. Only this function has this for maximum 
+	if !(XIM_bSystemEnabled) exitWith {}; 	//don't tell clients to play music if entire system is stopped. Only this function has this for maximum 
 											//compatibility (i.e. able to start and stop system without restarting the mission), but consider doing this in all the functions for 
 											//performance gains (so XIM scripts are barely running so resources aren't wasted on calculating what music to play even if that music
 											//will never actually get played thanks to this line in fncXIM_MusicRemote)?

--- a/addons/XIM_Core/scripts/singleplayer/client.sqf
+++ b/addons/XIM_Core/scripts/singleplayer/client.sqf
@@ -156,7 +156,7 @@ fncXIM_MusicRemote = {
 	(units _gXIMGroup) apply {_groupOwnerIDs pushBackUnique (owner _x)}; //Retrieving ID's for players in group
 	private _sXIM_MusicType = "";
 
-	if !(XIM_systemEnabled) exitWith {}; 	//don't play music if entire system is stopped. Only this function has this for maximum 
+	if !(XIM_bSystemEnabled) exitWith {}; 	//don't play music if entire system is stopped. Only this function has this for maximum 
 											//compatibility (i.e. able to start and stop system without restarting the mission), but consider doing this in all the functions for 
 											//performance gains (so XIM scripts are barely running so resources aren't wasted on calculating what music to play even if that music
 											//will never actually get played thanks to this line in fncXIM_MusicRemote)?
@@ -203,9 +203,9 @@ player setVariable ["XIM_bMusicStopped", false]; // set the XIM_bMusicStopped va
 
 addMusicEventHandler ["MusicStart", {
 	
-	if !(XIM_systemEnabled) exitWith {}; 	//if mission has disabled XIM, they probably don't want the 'Now Playing' UI to pop up when Zeus/other script starts a song 
+	if !(XIM_bSystemEnabled) exitWith {}; 	//if mission has disabled XIM, they probably don't want the 'Now Playing' UI to pop up when Zeus/other script starts a song 
 											//then again, the 'Now Playing' UI is kinda cool and Zeus/other might want it on. Consider removing this line and just adding a disclaimer to
-											//'XIM_systemEnabled' in the CBA options that they also need to disable XIM_bNowPlayingEnabled if they want to hide the 'Now Playing' UI too.
+											//'XIM_bSystemEnabled' in the CBA options that they also need to disable XIM_bNowPlayingEnabled if they want to hide the 'Now Playing' UI too.
 											
 	if (XIM_bNowPlayingEnabled) then
 	{

--- a/addons/XIM_Core/scripts/singleplayer/client.sqf
+++ b/addons/XIM_Core/scripts/singleplayer/client.sqf
@@ -156,6 +156,11 @@ fncXIM_MusicRemote = {
 	(units _gXIMGroup) apply {_groupOwnerIDs pushBackUnique (owner _x)}; //Retrieving ID's for players in group
 	private _sXIM_MusicType = "";
 
+	if !(XIM_systemEnabled) exitWith {}; 	//don't play music if entire system is stopped. Only this function has this for maximum 
+											//compatibility (i.e. able to start and stop system without restarting the mission), but consider doing this in all the functions for 
+											//performance gains (so XIM scripts are barely running so resources aren't wasted on calculating what music to play even if that music
+											//will never actually get played thanks to this line in fncXIM_MusicRemote)?
+
 	if (_bXIMCombatState) then { // if _bXIMCombatState is true
 
 		_sXIM_MusicType = "combat"; // then set the music type to combat
@@ -197,6 +202,11 @@ player setVariable ["XIM_bMusicStopped", false]; // set the XIM_bMusicStopped va
 ["ace_firedNonPlayerVehicle", XIM_fncMain] call CBA_fnc_addEventHandler; // adds event handler for when an AI fires inside a vehicle
 
 addMusicEventHandler ["MusicStart", {
+	
+	if !(XIM_systemEnabled) exitWith {}; 	//if mission has disabled XIM, they probably don't want the 'Now Playing' UI to pop up when Zeus/other script starts a song 
+											//then again, the 'Now Playing' UI is kinda cool and Zeus/other might want it on. Consider removing this line and just adding a disclaimer to
+											//'XIM_systemEnabled' in the CBA options that they also need to disable XIM_bNowPlayingEnabled if they want to hide the 'Now Playing' UI too.
+											
 	if (XIM_bNowPlayingEnabled) then
 	{
 		private _trackname = getText (configFile >> "CfgMusic" >> _this select 0 >> "name");


### PR DESCRIPTION
Description:
Adds an option to the CBA addon options of the mod to enable/disable playing music. To allow for being able to enable/disable the mod without needing to restart the mission or add a lot of new code, it simply exits `fncXIM_MusicRemote` and the client `MusicStart` event handler if the system is disabled. Additionally, the options to skip song and start/stop playing music in the ace action menu of the group leader are disabled while the system is disabled. It has some minor issues and it could have some improvements that haven't been added since they were outside of the original scope of my idea to "Make XIM able to be disabled in the simplest way possible, while keeping support for turning it back on without restarting the mission if wanted".

Note that the rest of the scripts still run since I don't pretend to be 100% familiar with how the functions interplay and I wanted to be sure that it wouldn't need a mission restart to change the setting. So, the other functions still run, it's just that actually playing music (and displaying the 'Now Playing' UI, see my comment at Line 30 of `scripts\multiplayer\client.sqf` for more info about why I made that decision) is disabled while the option for disabling the system is set. Those other scripts should be minimally performance intensive, but if someone more familiar than me wants to go in and refactor this to pause those scripts until the system is restarted for maximum performance, then go ahead.

Issues I need help with (some are actually issues, and some are design questions):

- [x] In the addon options, the new "Core" section with this overall enable/disable option is below "Combat variables" instead of being at the top of the addon options list for some reason.
- [ ] Possible MP compatibility issues, I've set the enable option to be global but I haven't used the CBA addon options system before so I need to check to make sure that server automatically overrides any client settings for it. It should work, just putting this here to cover my bases.
- [ ] Possible unwanted usage of processing resources (see description, no more than regular XIM uses. However, if user disabled XIM, it should be using no resources instead of minimal).
- [ ] If the setting is disabled and then re-enabled, XIM will not automatically play music until Zeus or another music script plays a song. This is because XIM plays a new song every time the current song ends (with some delay).

This has been tested in singleplayer and local multiplayer and appears to work. Since the mod is licensed under `LGPL` I can add it to my unit's custom mod for a couple weeks to test it on a dedicated server if you wish, however, a quick question first: the unit mod's code is in a publicly accessible Github page, so "any mods or modpacks (not steam collections) incorporating modified versions of our mod must publicly share their modified source code under the terms of the LGPL" is satisfied. However, a quick question about the "share" wording: is my entire mod now under the LGPL, or is only the PBO containing the modified code for my fork of XIM's Dynamic Music under the LGPL? Asking because while my code is publicly accessible, I don't allow redistribution of the code and assets that I make (not counting other mods I've been given permission to repack, which remain under their sharable licenses) without written permission from myself.